### PR TITLE
add verification for installation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,25 @@
 
 	This should show you a wall of text with info about your Docker daemon (or your Docker installation).
 
+4. Type : `docker run hello-world`
+
+   You should see
+    ```
+    Hello from Docker!
+    This message shows that your installation appears to be working correctly.
+
+    To generate this message, Docker took the following steps:
+    1. The Docker client contacted the Docker daemon.
+    2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+        (amd64)
+    3. The Docker daemon created a new container from that image which runs the
+        executable that produces the output you are currently reading.
+    4. The Docker daemon streamed that output to the Docker client, which sent it
+        to your terminal.
+
+    .....
+    ```
+
 ## Installation for Windows 10 Home Edition
 
 1. Visit https://docs.docker.com/toolbox/toolbox_install_windows/ to follow the instruction to install Docker Toolbox.


### PR DESCRIPTION
This is to add additional verification to for people that installed Docker for Windows or Mac. 

Previously I had an experience even when Docker is installed, they had issues pulling images from Docker Hub. 

To be safe, adding this verification helps reduce the issues for students when they installed it before hand.